### PR TITLE
feat(authentication): middlewares for json done

### DIFF
--- a/w1/config/jwt.go
+++ b/w1/config/jwt.go
@@ -50,7 +50,7 @@ func (jt *jsonToken) GenerateJWT(data map[string]interface{}) (string, error) {
 		claims[key] = value
 	}
 	claims["nbf"] = time.Now().Unix()
-	claims["exp"] = jt.getExpirationTIme()
+	claims["exp"] = jt.getExpirationTIme().Unix()
 
 	// Create a new JWT token with the claims and signing method
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/w1/middlewares/auth_middleware.go
+++ b/w1/middlewares/auth_middleware.go
@@ -1,0 +1,60 @@
+package middlewares
+
+import (
+	"fmt"
+	"gin-mvc/config"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// AuthMiddleware is a middleware function to authenticate requests using JWT
+func AuthMiddleware() gin.HandlerFunc {
+	jwtConfig := config.NewJWT()
+	return func(c *gin.Context) {
+		// Get the JWT token from the Authorization header
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Token is required"})
+			return
+		}
+
+		authHeaderParts := strings.Split(authHeader, " ")
+		if len(authHeaderParts) != 2 || authHeaderParts[0] != "Bearer" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid Authorization header"})
+			return
+		}
+
+		// Extract the JWT token
+		tokenString := authHeaderParts[1]
+		// Parse the JWT token
+		// log.Println(tokenString)
+		// log.Println(jwtConfig.GetSigningKey())
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+			// Check the signing method
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("invalid token signing method")
+			}
+			// Provide the secret key used to sign the token
+			return []byte(jwtConfig.GetSigningKey()), nil
+		})
+		// log.Println(token)
+		if err != nil {
+			log.Println(err)
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
+			return
+		}
+
+		// Check if the token is valid
+		if !token.Valid {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
+			return
+		}
+
+		// If the token is valid, continue with the request
+		c.Next()
+	}
+}

--- a/w1/routes/routes.go
+++ b/w1/routes/routes.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"gin-mvc/controllers"
+	"gin-mvc/middlewares"
 
 	"github.com/gin-gonic/gin"
 )
@@ -10,8 +11,11 @@ func RegisterRoutes(r *gin.Engine) {
 	r.GET("/ping", controllers.Ping)
 	v1 := r.Group("/v1")
 	{
+		// public route without auth middleware
 		v1.POST("/login", controllers.Login)
 
+		// private route with auth middleware
+		v1.GET("/ping-private", middlewares.AuthMiddleware(), controllers.Ping)
 	}
 
 }


### PR DESCRIPTION
Add middlewares auth for jwt with sample url ping private

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an authentication middleware for JWT tokens in the application.
  - Added a secure, authenticated private route `/ping-private`.

- **Bug Fixes**
  - Updated JWT expiration time handling to use Unix timestamp format for better compatibility and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->