### PR TITLE
feat(w2-migration): add foreign key to all tables, fix column

### DIFF
--- a/w2/migrations/20240508023227_checkouts.up.sql
+++ b/w2/migrations/20240508023227_checkouts.up.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS public.checkouts (
     customer_id uuid NOT NULL,
     paid int NOT NULL,
     change int NOT NULL,
-    created_by uuid,
+    created_by uuid NOT NULL,
     created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT checkouts_pkey PRIMARY KEY (id),

--- a/w2/migrations/20240508134350_products_add_foreign_key.down.sql
+++ b/w2/migrations/20240508134350_products_add_foreign_key.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.products
+    DROP CONSTRAINT IF EXISTS products_fk_created_by;

--- a/w2/migrations/20240508134350_products_add_foreign_key.up.sql
+++ b/w2/migrations/20240508134350_products_add_foreign_key.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.products
+    ADD CONSTRAINT products_fk_created_by
+        FOREIGN KEY (created_by) 
+        REFERENCES public.users(user_id)
+        ON DELETE CASCADE;

--- a/w2/migrations/20240508140237_checkouts__add_foreign_key.down.sql
+++ b/w2/migrations/20240508140237_checkouts__add_foreign_key.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.checkouts
+    DROP CONSTRAINT IF EXISTS checkouts_fk_customer_id;
+
+ALTER TABLE public.checkouts
+    DROP CONSTRAINT IF EXISTS checkouts_fk_user_id;

--- a/w2/migrations/20240508140237_checkouts__add_foreign_key.up.sql
+++ b/w2/migrations/20240508140237_checkouts__add_foreign_key.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE public.checkouts
+    ADD CONSTRAINT checkouts_fk_customer_id 
+        FOREIGN KEY (customer_id) 
+        REFERENCES public.customers(id)
+        ON DELETE CASCADE;
+
+ALTER TABLE public.checkouts
+    ADD CONSTRAINT checkouts_fk_user_id 
+        FOREIGN KEY (created_by) 
+        REFERENCES public.users(user_id)
+        ON DELETE CASCADE;

--- a/w2/migrations/20240508141350_checkout_items_add_foreign_key.up.sql
+++ b/w2/migrations/20240508141350_checkout_items_add_foreign_key.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE checkout_items
+    ADD CONSTRAINT checkout_items_fk_checkout_id 
+    FOREIGN KEY (checkout_id) 
+    REFERENCES public.checkouts(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE checkout_items
+    ADD CONSTRAINT checkout_items_fk_product_id 
+    FOREIGN KEY (product_id) 
+    REFERENCES public.products(id)
+    ON DELETE CASCADE;


### PR DESCRIPTION
1. Adding foreign keys to all tables that need it
2. Fix checkouts created by column has not been set to not null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data integrity in the database by enforcing non-nullability for the `created_by` field in the `checkouts` table.
	- Added foreign key constraints to the `products` and `checkouts` tables to ensure referential integrity with the `users` and `customers` tables, including cascade delete actions.
	- Established foreign key relationships in the `checkout_items` table to link with `checkouts` and `products` tables, supporting automatic updates and deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->