### PR TITLE
feat(w3-patients): change phone number validation, add browse patient

### DIFF
--- a/w3/domain/entity/options.go
+++ b/w3/domain/entity/options.go
@@ -1,0 +1,53 @@
+package entity
+
+type SortType string
+
+const (
+	ASC  SortType = "asc"
+	DESC SortType = "desc"
+)
+
+func (s SortType) String() string {
+	return string(s)
+}
+
+type BrowseMedicalRecordPatientOptionBuilder func(*BrowseMedicalRecordPatientOption)
+type BrowseMedicalRecordPatientOption struct {
+	Limit          int
+	Offset         int
+	IdentityNumber *int
+	Name           string
+	PhoneNumber    *int
+	SortCreatedAt  SortType
+}
+
+func WithOffsetAndLimit(offset, limit int) BrowseMedicalRecordPatientOptionBuilder {
+	return func(b *BrowseMedicalRecordPatientOption) {
+		b.Limit = limit
+		b.Offset = offset
+	}
+}
+
+func WithIdentityNumber(identityNumber int) BrowseMedicalRecordPatientOptionBuilder {
+	return func(b *BrowseMedicalRecordPatientOption) {
+		b.IdentityNumber = &identityNumber
+	}
+}
+
+func WithName(name string) BrowseMedicalRecordPatientOptionBuilder {
+	return func(b *BrowseMedicalRecordPatientOption) {
+		b.Name = name
+	}
+}
+
+func WithPhoneNumber(phoneNumber int) BrowseMedicalRecordPatientOptionBuilder {
+	return func(b *BrowseMedicalRecordPatientOption) {
+		b.PhoneNumber = &phoneNumber
+	}
+}
+
+func WithSortCreatedAt(sortCreatedAt SortType) BrowseMedicalRecordPatientOptionBuilder {
+	return func(b *BrowseMedicalRecordPatientOption) {
+		b.SortCreatedAt = sortCreatedAt
+	}
+}

--- a/w3/domain/repository/medical_record_patient_repository.go
+++ b/w3/domain/repository/medical_record_patient_repository.go
@@ -3,7 +3,9 @@ package repository
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"halosuster/domain/entity"
+	"strings"
 )
 
 type medicalRecordPatientRepository struct {
@@ -13,6 +15,7 @@ type medicalRecordPatientRepository struct {
 type IMedicalRecordPatientRepository interface {
 	Exists(id int) (bool, error)
 	Create(patient entity.MedicalRecordPatient) (entity.MedicalRecordPatient, error)
+	Browse(builder ...entity.BrowseMedicalRecordPatientOptionBuilder) ([]entity.MedicalRecordPatient, error)
 }
 
 func NewMedicalRecordPatientRepository(db *sql.DB) *medicalRecordPatientRepository {
@@ -43,4 +46,69 @@ func (r *medicalRecordPatientRepository) Exists(id int) (bool, error) {
 	}
 
 	return exists, nil
+}
+
+func (r *medicalRecordPatientRepository) Browse(builder ...entity.BrowseMedicalRecordPatientOptionBuilder) ([]entity.MedicalRecordPatient, error) {
+	var (
+		patients   []entity.MedicalRecordPatient
+		conditions []string = make([]string, 0)
+		values     []any    = make([]any, 0)
+		sort       string
+	)
+
+	options := &entity.BrowseMedicalRecordPatientOption{}
+	for _, o := range builder {
+		o(options)
+	}
+
+	if options.IdentityNumber != nil {
+		values = append(values, *options.IdentityNumber)
+		conditions = append(conditions, fmt.Sprintf("id = $%d", len(values)))
+	}
+
+	if options.Name != "" {
+		values = append(values, "%"+options.Name+"%")
+		conditions = append(conditions, fmt.Sprintf("name ILIKE $%d", len(values)))
+	}
+
+	if options.PhoneNumber != nil {
+		values = append(values, fmt.Sprintf("'+%d%%'", *options.PhoneNumber))
+		conditions = append(conditions, fmt.Sprintf("phone_number ILIKE $%d", len(values)))
+	}
+
+	if options.Limit == 0 {
+		options.Limit = 5
+	}
+
+	if options.SortCreatedAt.String() != "" {
+		sort = fmt.Sprintf("ORDER BY created_at %s", options.SortCreatedAt.String())
+	}
+
+	WHERE := ""
+	if len(conditions) > 0 {
+		WHERE = "WHERE"
+	}
+
+	query := fmt.Sprintf(`
+		SELECT id, phone_number, name, birth_date, gender, created_at FROM public.patients
+		%s %s %s LIMIT %d OFFSET %d
+	`, WHERE, strings.Join(conditions, " AND "), sort, options.Limit, options.Offset)
+
+	fmt.Println(query, values)
+	res, err := r.db.Query(query, values...)
+	if err != nil {
+		return patients, err
+	}
+
+	for res.Next() {
+		var patient entity.MedicalRecordPatient
+		err = res.Scan(&patient.ID, &patient.PhoneNumber, &patient.Name, &patient.BirthDate, &patient.Gender, &patient.CreatedAt)
+		if err != nil {
+			return []entity.MedicalRecordPatient{}, err
+		}
+
+		patients = append(patients, patient)
+	}
+
+	return patients, nil
 }

--- a/w3/domain/usecase/medical_record_patient_usecase.go
+++ b/w3/domain/usecase/medical_record_patient_usecase.go
@@ -6,26 +6,28 @@ import (
 	"time"
 )
 
-type iPatientRepository interface {
+type iMedicalRecordPatientRepository interface {
+	Browse(builder ...entity.BrowseMedicalRecordPatientOptionBuilder) ([]entity.MedicalRecordPatient, error)
 	Create(patient entity.MedicalRecordPatient) (entity.MedicalRecordPatient, error)
 	Exists(id int) (bool, error)
 }
 
 type medicalRecordPatientUsecase struct {
-	patientRepository iPatientRepository
+	patientRepository iMedicalRecordPatientRepository
 }
 
 type IMedicalRecordPatientUsecase interface {
 	Create(req MedicalRecordPatientCreateRequest) (MedicalRecordPatientCreateResponse, error)
+	Browse(query MedicalRecordPatientBrowseQuery) ([]MedicalRecordPatientBrowseResponse, error)
 }
 
-func NewMedicalRecordPatientUsecase(patientRepository iPatientRepository) *medicalRecordPatientUsecase {
+func NewMedicalRecordPatientUsecase(patientRepository iMedicalRecordPatientRepository) *medicalRecordPatientUsecase {
 	return &medicalRecordPatientUsecase{patientRepository}
 }
 
 type MedicalRecordPatientCreateRequest struct {
 	IdentityNumber      int    `json:"identityNumber" validate:"required,numeric"`
-	PhoneNumber         string `json:"phoneNumber" validate:"required,phone,min=10,max=15"`
+	PhoneNumber         string `json:"phoneNumber" validate:"required,startswith=+62,min=10,max=15"`
 	Name                string `json:"name" validate:"required,min=3,max=30"`
 	BirthDate           string `json:"birthDate" validate:"required,date"`
 	Gender              string `json:"gender" validate:"required,oneof=male female"`
@@ -80,4 +82,75 @@ func (u *medicalRecordPatientUsecase) Create(req MedicalRecordPatientCreateReque
 		Name:           patient.Name,
 		CreatedAt:      patient.CreatedAt.Format(time.RFC3339),
 	}, nil
+}
+
+type MedicalRecordPatientBrowseQuery struct {
+	Limit          int    `query:"limit"`
+	Offset         int    `query:"offset"`
+	IdentityNumber int    `query:"identityNumber"`
+	Name           string `query:"name"`
+	PhoneNumber    *int   `query:"phoneNumber"`
+	SortCreatedAt  string `query:"createdAt"`
+}
+
+type MedicalRecordPatientBrowseResponse struct {
+	ID          int    `json:"identityNumber"`
+	PhoneNumber string `json:"phoneNumber"`
+	Name        string `json:"name"`
+	BirthDate   string `json:"birthDate"`
+	Gender      string `json:"gender"`
+	CreatedAt   string `json:"createdAt"`
+}
+
+func (u *medicalRecordPatientUsecase) Browse(query MedicalRecordPatientBrowseQuery) ([]MedicalRecordPatientBrowseResponse, error) {
+	var (
+		options  []entity.BrowseMedicalRecordPatientOptionBuilder
+		response []MedicalRecordPatientBrowseResponse = make([]MedicalRecordPatientBrowseResponse, 0)
+	)
+
+	if query.Limit <= 0 {
+		query.Limit = 5
+	}
+
+	if query.Offset < 0 {
+		query.Offset = 0
+	}
+
+	options = append(options, entity.WithOffsetAndLimit(query.Offset, query.Limit))
+
+	if query.IdentityNumber > 0 {
+		options = append(options, entity.WithIdentityNumber(query.IdentityNumber))
+	}
+
+	if query.Name != "" {
+		options = append(options, entity.WithName(query.Name))
+	}
+
+	if query.PhoneNumber != nil {
+		options = append(options, entity.WithPhoneNumber(*query.PhoneNumber))
+	}
+
+	if query.SortCreatedAt == entity.ASC.String() {
+		options = append(options, entity.WithSortCreatedAt(entity.ASC))
+	} else {
+		options = append(options, entity.WithSortCreatedAt(entity.DESC))
+	}
+
+	patients, err := u.patientRepository.Browse(options...)
+	if err != nil {
+		return response, err
+	}
+
+	for _, patient := range patients {
+		response = append(response, MedicalRecordPatientBrowseResponse{
+			ID:          patient.ID,
+			PhoneNumber: patient.PhoneNumber,
+			Name:        patient.Name,
+			BirthDate:   patient.BirthDate.Format("2006-01-02"),
+			Gender:      patient.Gender,
+			CreatedAt:   patient.CreatedAt.Format(time.RFC3339),
+		})
+	}
+
+	return response, nil
 }

--- a/w3/protocol/api/controller/medical_record_patient_controller.go
+++ b/w3/protocol/api/controller/medical_record_patient_controller.go
@@ -11,10 +11,12 @@ import (
 
 type iMedicalRecordPatientUsecase interface {
 	Create(req usecase.MedicalRecordPatientCreateRequest) (usecase.MedicalRecordPatientCreateResponse, error)
+	Browse(query usecase.MedicalRecordPatientBrowseQuery) ([]usecase.MedicalRecordPatientBrowseResponse, error)
 }
 
 type IMedicalRecordPatientController interface {
 	Create(c *fiber.Ctx) error
+	Browse(c *fiber.Ctx) error
 }
 
 type medicalRecordPatientController struct {
@@ -45,6 +47,21 @@ func (ctr *medicalRecordPatientController) Create(c *fiber.Ctx) error {
 
 	return c.Status(http.StatusCreated).JSON(dto.PatientRegisterControllerResponse{
 		Message: "patient registered successfully",
+		Data:    data,
+	})
+}
+
+func (ctr *medicalRecordPatientController) Browse(c *fiber.Ctx) error {
+	var query usecase.MedicalRecordPatientBrowseQuery
+	c.QueryParser(&query)
+
+	data, err := ctr.patientUsecase.Browse(query)
+	if err != nil {
+		return err
+	}
+
+	return c.Status(http.StatusOK).JSON(dto.PatientRegisterControllerResponse{
+		Message: "success",
 		Data:    data,
 	})
 }

--- a/w3/protocol/api/dto/medical_record_patient_dto.go
+++ b/w3/protocol/api/dto/medical_record_patient_dto.go
@@ -4,3 +4,8 @@ type PatientRegisterControllerResponse struct {
 	Message string `json:"message"`
 	Data    any    `json:"data"`
 }
+
+type PatientBrowseControllerResponse struct {
+	Message string `json:"message"`
+	Data    any    `json:"data"`
+}

--- a/w3/protocol/api/route/private_route.go
+++ b/w3/protocol/api/route/private_route.go
@@ -59,4 +59,5 @@ func PrivateRoutes(params PrivateRouteParams) {
 
 	medical := route.Group("/medical")
 	medical.Post("/patient", medicalRecordPatientController.Create)
+	medical.Get("/patient", medicalRecordPatientController.Browse)
 }


### PR DESCRIPTION
1. change phone number validation to startswith +62
2. add browse patient end point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a browsing functionality for medical record patients.
  - Added a GET route for `/medical/patient` to browse medical record patients.

- **Improvements**
  - Enhanced the patient browsing experience by allowing filtering based on identity number, name, and phone number.
  - Added sorting options for browsing medical records.

- **API Changes**
  - Updated the `medicalRecordPatientController` to include a `Browse` method.
  - Added `PatientBrowseControllerResponse` for handling browse responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->