### PR TITLE
feat(w3-user-nip): fix validation, change error handling

### DIFF
--- a/w3/domain/entity/user_entity.go
+++ b/w3/domain/entity/user_entity.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"net/url"
 	"path/filepath"
@@ -42,7 +43,8 @@ func (u User) HasAccess() bool {
 // true when the NIP is valid
 func ValidateUserNIP(nip string, role UserRole) bool {
 	// Check length
-	if len(nip) != 13 {
+	// as per the latest requirement, nip length changed to 15 (from 13)
+	if len(nip) != 15 {
 		return false
 	}
 
@@ -80,7 +82,9 @@ func ValidateUserNIP(nip string, role UserRole) bool {
 	}
 
 	// Check random digits (11th to 13th digit)
-	if _, err := strconv.Atoi(nip[10:13]); err != nil {
+	// as per the latest requirement, nip length changed to 15 (from 13)
+	if _, err := strconv.Atoi(nip[10:15]); err != nil {
+		fmt.Println("disini?", err.Error())
 		return false
 	}
 

--- a/w3/migrations/20240513155027_users.up.sql
+++ b/w3/migrations/20240513155027_users.up.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 CREATE TABLE IF NOT EXISTS public.users(
     id uuid NOT NULL DEFAULT uuid_generate_v4(),
-    nip character(13) NULL,
+    nip character(15) NULL,
     name character varying(50) NOT NULL,
     password character(72) DEFAULT NULL,
     role character varying(20) NOT NULL,

--- a/w3/protocol/api/controller/user_it_controller.go
+++ b/w3/protocol/api/controller/user_it_controller.go
@@ -76,13 +76,11 @@ func (pc *userITController) LoginUserIT(c *fiber.Ctx) error {
 	// TODO: add logic
 	data, err := pc.userITUsecase.LoginUserIT(request)
 	if err != nil {
-		// tar ganti
-		// dirty dulu.
-		return c.Status(http.StatusInternalServerError).JSON(err)
+		return err
 	}
 	// TODO: return response
 
-	return c.Status(http.StatusCreated).JSON(dto.UserITRegisterControllerResponse{
+	return c.Status(http.StatusOK).JSON(dto.UserITRegisterControllerResponse{
 		Message: "user login successfully",
 		Data:    data,
 	})


### PR DESCRIPTION
1. Fix nip validation 15 from 13
2. Change migration nip column to 15 from 13
3. Change custom error handling on register IT user
4. Check if nip exists on register IT user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded NIP field length from 13 to 15 characters for user registration and login.

- **Bug Fixes**
  - Improved error handling in user login to return specific errors instead of generic internal server errors.
  - Updated HTTP status code on successful login from 201 (Created) to 200 (OK).

- **Database**
  - Increased NIP field length in the users table from 13 to 15 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->