### PR TITLE
fix(merchant-nearby): adjust endpoint param, nearby query

### DIFF
--- a/w4/protocol/api/controller/merchant_controller.go
+++ b/w4/protocol/api/controller/merchant_controller.go
@@ -4,7 +4,6 @@ import (
 	"belimang/domain/usecase"
 	"belimang/internal/helper"
 	"context"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -75,7 +74,8 @@ func (c *merchantController) BrowseNearby(ctx *fiber.Ctx) error {
 
 	_, span := tracer.Start(context, "Browse")
 	defer span.End()
-	coordinate := strings.Split(ctx.Params("latlon"), ",")
+	// coordinate := strings.Split(ctx.Params("latlon"), ",")
+	coordinate := []string{ctx.Params("lat"), ctx.Params("lon")}
 	coordinate[0] = strings.TrimSpace(coordinate[0])
 	coordinate[1] = strings.TrimSpace(coordinate[1])
 
@@ -89,8 +89,6 @@ func (c *merchantController) BrowseNearby(ctx *fiber.Ctx) error {
 		return fiber.ErrBadRequest
 	}
 
-	log.Println(lat)
-	log.Println(lon)
 	var query usecase.MerchantFetchQuery
 
 	if err := ctx.QueryParser(&query); err != nil {

--- a/w4/protocol/api/route/private_route.go
+++ b/w4/protocol/api/route/private_route.go
@@ -48,7 +48,5 @@ func PrivateRoutes(params PrivateRouteParam) {
 		router.Get("/orders", orderController.GetUserOrders)
 	})
 
-	params.App.Route("/merchants/nearby/:latlon", func(router fiber.Router) {
-		router.Get("/", merchantController.BrowseNearby)
-	})
+	params.App.Get("/merchants/nearby/:lat/:lon", merchantController.BrowseNearby)
 }


### PR DESCRIPTION
Changes:
1. Adjust endpoint param to `:lat/:on` instead of `:latlon` since the requested parameters from K6 is as such
2. Adjust nearby query to isolate geohash and filter then give them `AND` parameter in between

Even though the changes has been made, I still got an error when the K6 reach this case:
`User Get Nearby Merchant | with merchantCategory=BoothKiosk param`

I have already directly test query generated from the repository by only using the geohash conditions and the result is still `empty` (**even without category filter**)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the merchant search functionality with improved geographic filtering for more accurate results.

- **Improvements**
  - Streamlined route parameters for browsing nearby merchants, making it easier to specify latitude and longitude directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->